### PR TITLE
Write all numbers as floats

### DIFF
--- a/nodes/InfluxDb/influxdb.node.utils.ts
+++ b/nodes/InfluxDb/influxdb.node.utils.ts
@@ -48,13 +48,9 @@ export async function writeData(client: InfluxDB, data: [], org: string, bucket:
 					break;
 				}
 				case 'number': {
-					if (Number.isInteger(dataItem[field])) { // int
-						point = point.intField(field, dataItem[field] as number);
-						break;
-					} else { // float
-						point = point.floatField(field, dataItem[field] as number);
-						break;
-					}
+					// write all numbers as floats, see https://github.com/influxdata/influxdb/issues/3460#issuecomment-124747104
+					point = point.floatField(field, dataItem[field] as number);
+					break;
 				}
 				case 'string': {
 					point = point.stringField(field, dataItem[field] as string);


### PR DESCRIPTION
I had the type conflict issues for numbers. 
Both the:
1) 'write failed: field type conflict: input field "XYZ" on measurement "ZYX" is type int64, already exists as type float
2) 'write failed: field type conflict: input field "ABC" on measurement "ZYX" is type float64, already exists as type integer

InfluxDB (v2) sets the type int or float for a specific field based on the data first written (to a shard(!) impossible to control) and since javascript/typescript both input values 1.0 and 1 are Number.isInteger == true, then it's only a matter of time before a subsequent write fails in the above mentioned errors. 

An old InfluxDB discussion (2015) suggest always writing numbers as floats (except for the timestamp), so this PR suggests doing the same in the n8n-nodes-influxdb-package. 